### PR TITLE
style: run deno fmt to unify styling

### DIFF
--- a/assets/js/extension.js
+++ b/assets/js/extension.js
@@ -1,52 +1,52 @@
 import Quill from "quill";
-import QuillMarkdown from 'quilljs-markdown'
+import QuillMarkdown from "quilljs-markdown";
 import "quill-mention";
-import { Picker } from 'emoji-mart'
+import { Picker } from "emoji-mart";
 
 let EditorQuillHooks = {};
-let global_quill = null
+let global_quill = null;
 
-EditorQuillHooks.QuillEditor = { 
+EditorQuillHooks.QuillEditor = {
   mounted() {
-    const container = document.querySelector("#smart_input")
-    const area = this.el.querySelector("#editor")
+    const container = document.querySelector("#smart_input");
+    const area = this.el.querySelector("#editor");
     console.log("editor - quill loading for element with id #editor");
 
     const supported_formats = [
-      'text',
+      "text",
       // 'background',
-      'bold',
+      "bold",
       // 'color',
       // 'font',
-      'code',
-      'italic',
-      'link',
+      "code",
+      "italic",
+      "link",
       // 'size',
-      'strike',
-      'script', // Superscript/Subscript 
-      'underline',
-      'blockquote',
-      'header',
-      'indent',
-      'list',
+      "strike",
+      "script", // Superscript/Subscript
+      "underline",
+      "blockquote",
+      "header",
+      "indent",
+      "list",
       // 'align',
-      'direction',
-      'code-block'
+      "direction",
+      "code-block",
       // 'formula'
       // 'image'
       // 'video'
     ];
 
     const quill = new Quill(area, {
-      theme: 'bubble',
+      theme: "bubble",
       placeholder: area.dataset.placeholder,
       formats: supported_formats,
       modules: {
         toolbar: [
-          ['link'],
-          ['bold', 'italic'],
+          ["link"],
+          ["bold", "italic"],
           // [{ header: [2, 3, false] }],
-          [{ 'list': 'ordered' }, { 'list': 'bullet' }, 'blockquote'],
+          [{ "list": "ordered" }, { "list": "bullet" }, "blockquote"],
           // ['code-block']
         ],
         mention: {
@@ -54,118 +54,130 @@ EditorQuillHooks.QuillEditor = {
           fixMentionsToQuill: true,
           mentionDenotationChars: ["@", "&", "+"],
           showDenotationChar: true,
-          blotName: 'text',
+          blotName: "text",
           spaceAfterInsert: false,
-          source: async function(searchTerm, renderList, mentionChar) {
-            const matchedValues = await getFeedItems(searchTerm, mentionChar)
-            renderList(matchedValues)
+          source: async function (searchTerm, renderList, mentionChar) {
+            const matchedValues = await getFeedItems(searchTerm, mentionChar);
+            renderList(matchedValues);
           },
           onSelect: function (item, insertItem) {
             // console.log(item.id)
-            insertItem(item.id+" ") // if using 'text' blot
+            insertItem(item.id + " "); // if using 'text' blot
             quill.setSelection(quill.getLength(), 0); // TODO: move cursor after mention
           },
-          renderItem: function(item, searchTerm) {
+          renderItem: function (item, searchTerm) {
             return `
               <div class="flex flex-col py-2">
                 <div class="text-sm text-slate-800 font-semibold">${item.value}</div>
                 <div class="text-xs text-slate-800 text-opacity-70 font-regular">${item.id}</div>
               </div>
             `;
-          }
-        }
-      }
+          },
+        },
+      },
     });
 
     window.quill = quill;
 
-    if (this.el.dataset.insert_text != undefined && this.el.dataset.insert_text.length > 0) {
-      const range = quill.getSelection() 
+    if (
+      this.el.dataset.insert_text != undefined &&
+      this.el.dataset.insert_text.length > 0
+    ) {
+      const range = quill.getSelection();
       if (range != null) {
-        quill.insertText(range.index, this.el.dataset.insert_text + ' ', 'user', true)
+        quill.insertText(
+          range.index,
+          this.el.dataset.insert_text + " ",
+          "user",
+          true,
+        );
       } else {
-        quill.insertText(0, this.el.dataset.insert_text + ' ', 'user', true)
+        quill.insertText(0, this.el.dataset.insert_text + " ", "user", true);
       }
     }
 
-    quill.on('text-change', (delta, oldDelta, source) => {
-      if (source == 'api') {
-          console.log("An API call triggered this change."); 
-          this.el.querySelector('#quill_content').value = quill.root.innerHTML;
-          // console.log(quill.root.innerHTML)
-        } else if (source == 'user') {
-          this.el.querySelector('#quill_content').value = quill.root.innerHTML;
-			}
-    })
+    quill.on("text-change", (delta, oldDelta, source) => {
+      if (source == "api") {
+        console.log("An API call triggered this change.");
+        this.el.querySelector("#quill_content").value = quill.root.innerHTML;
+        // console.log(quill.root.innerHTML)
+      } else if (source == "user") {
+        this.el.querySelector("#quill_content").value = quill.root.innerHTML;
+      }
+    });
 
     const getFileFromUrl = async function (url) {
       // note: this will only work for remote images served with appropriate CORS headers
-      const response = await fetch(url)
-      const data = await response.blob()
+      const response = await fetch(url);
+      const data = await response.blob();
       return data;
-    }
-    
-    setFileInput = function (data, input, name, defaultType = 'image/jpeg') {
+    };
+
+    setFileInput = function (data, input, name, defaultType = "image/jpeg") {
       // console.log(data)
-      var split = data.toString().split(';base64,');
+      var split = data.toString().split(";base64,");
       var type = data.type || defaultType;
-      var ext = type.split('/')[1];
-      // console.log(split) 
-      file = new File([split[1] || data], name+"."+ext, {
+      var ext = type.split("/")[1];
+      // console.log(split)
+      file = new File([split[1] || data], name + "." + ext, {
         type: type,
-      })
-      console.log(file) 
+      });
+      console.log(file);
       let container = new DataTransfer();
       container.items.add(file);
       input.files = container.files;
       var event = document.createEvent("HTMLEvents"); // bubble up to LV
       event.initEvent("input", true, true);
-      input.dispatchEvent(event); 
-    }
+      input.dispatchEvent(event);
+    };
 
-    quill.clipboard.addMatcher('IMG', (node, delta) => {
+    quill.clipboard.addMatcher("IMG", (node, delta) => {
       // console.log(node)
-      const Delta = Quill.import('delta')
+      const Delta = Quill.import("delta");
       let src = node.src;
-      const input = container.querySelector("input[type=file]")
+      const input = container.querySelector("input[type=file]");
       // console.log(input)
       if (src && input) {
-        getFileFromUrl(src).then(file => setFileInput(file, input, node.alt || "image"))
+        getFileFromUrl(src).then((file) =>
+          setFileInput(file, input, node.alt || "image")
+        );
       }
-      return new Delta().insert('')
-    })
+      return new Delta().insert("");
+    });
 
-    // global_quill = quill; 
-    
+    // global_quill = quill;
+
     // markdown is enabled
-    const quillMarkdown = new QuillMarkdown(quill, { ignoreTags: ['ul', 'ol', 'checkbox']})
+    const quillMarkdown = new QuillMarkdown(quill, {
+      ignoreTags: ["ul", "ol", "checkbox"],
+    });
     const picker = new Picker({
       emojiButtonSize: 30,
       emojiSize: 20,
-      previewPosition: 'none',
-      onEmojiSelect: function(emoji) {
-        const range = quill.getSelection() 
+      previewPosition: "none",
+      onEmojiSelect: function (emoji) {
+        const range = quill.getSelection();
         if (range != null) {
-          quill.insertText(range.index, emoji.native + ' ', 'user', true)
+          quill.insertText(range.index, emoji.native + " ", "user", true);
         } else {
-          quill.insertText(0, emoji.native + ' ', 'user', true)
+          quill.insertText(0, emoji.native + " ", "user", true);
         }
       },
       data: async () => {
         const response = await fetch(
-          'https://cdn.jsdelivr.net/npm/@emoji-mart/data',
-        )
-    
-        return response.json()
-      }
-    })
-    
-    container.querySelector('#picker').appendChild(picker)
+          "https://cdn.jsdelivr.net/npm/@emoji-mart/data",
+        );
 
-    this.handleEvent("smart_input:set_body", e => {
-      console.log(e)
-      quill.setText(e.text ? e.text : "\n")
-    })
+        return response.json();
+      },
+    });
+
+    container.querySelector("#picker").appendChild(picker);
+
+    this.handleEvent("smart_input:set_body", (e) => {
+      console.log(e);
+      quill.setText(e.text ? e.text : "\n");
+    });
 
     // Assuming there is a <form class="with_editor"> in your application.
     // document.querySelector('form.with_editor').addEventListener('submit', (event) => {
@@ -182,19 +194,17 @@ EditorQuillHooks.QuillEditor = {
     //     // quill.setText('\n')
     //   }
     // });
-
   },
   updated() {
-    console.log("quill updated")
-    console.log(this.el.dataset.insert_text)
-  }
+    console.log("quill updated");
+    console.log(this.el.dataset.insert_text);
+  },
 };
-
 
 function getFeedItems(queryText, prefix) {
   // console.log(prefix)
   if (queryText && queryText.length > 0) {
-    return new Promise((resolve) => { 
+    return new Promise((resolve) => {
       // this requires the bonfire_tag extension
       fetch("/api/tag/autocomplete/ck5/" + prefix + "/" + queryText)
         .then((response) => response.json())
@@ -202,8 +212,8 @@ function getFeedItems(queryText, prefix) {
           let values = data.map((item) => ({
             id: item.id,
             value: item.name,
-            link: item.link
-          }))
+            link: item.link,
+          }));
           // console.log(values);
           resolve(values);
         })
@@ -215,4 +225,4 @@ function getFeedItems(queryText, prefix) {
   } else return [];
 }
 
-export { EditorQuillHooks }
+export { EditorQuillHooks };


### PR DESCRIPTION
The following patch updates js styling to use deno formatter[^1]. In
doing so, allowing to use a consistent styling. Removing the
need to fiddle with settings of what styling is used. Prettier[^2] is
another option that can be used to reach the same consensus on styling.

In this context, used Deno's formatter as it really gets out of the way
on formatting and is compatible with the style prettier would provide,
if using the same sane defaults.

The main prupose here was to clear out styling from upcoming patch for
[403][3] with actual changes the patch provides. Making it easier for
review what has changed.

[^1]: https://deno.land/manual/tools/formatter
[^2]: https://prettier.io/

[3]: https://github.com/bonfire-networks/bonfire-app/issues/403